### PR TITLE
Fix publications page rendering

### DIFF
--- a/content/publications/_index.md
+++ b/content/publications/_index.md
@@ -4,8 +4,4 @@ title: "Publications"
 
 Our latest publications.
 
-<<<<<<< HEAD
-{{< publications author="Dawid Zyla" >}}
-=======
-{{< publications file="publications.bib" >}}
->>>>>>> 9003ab513497d61033d8681379dbb57ae8b0d1f5
+{{< publications >}}

--- a/layouts/shortcodes/publications.html
+++ b/layouts/shortcodes/publications.html
@@ -1,46 +1,27 @@
 {{/*
   Renders a list of publications from data/publications.json.
-  This file should be generated from your .bib file using the provided Python script.
-
-  This approach is more robust and maintainable than parsing BibTeX with regex.
-
   Usage: {{< publications >}}
 */}}
 
-{{/* Default to loading data from `site.Data.publications` */}}
 {{- $pubs := site.Data.publications -}}
 
 {{- if not $pubs -}}
-  {{/* Provide a helpful error message if the data file is missing */}}
-  {{- errorf "Could not find publications data in data/publications.json. Please run the 'scripts/bib_to_json.py' script to generate it from your publications.bib file." -}}
+  {{- errorf "Could not find publications data in data/publications.json." -}}
 {{- else -}}
 <ol class="publications-list">
-  {{/* Sort publications by year in descending order */}}
   {{- range sort $pubs "year" "desc" -}}
+    {{- $p := . -}}
     <li class="publication-item">
-      <p class="publication-title">{{ .title | plainify }}</p>
-      <p class="publication-authors">{{ .author | plainify }}</p>
-      <p class="publication-meta">
-        <em>{{ .journal | plainify }}</em>
-        {{- with .volume -}}
-          <strong>{{ . }}</strong>
-        {{- end -}}
-        {{- with .pages -}}
-          :{{ . | plainify }}
-        {{- end -}}
-        ({{ .year }}).
-      </p>
-      <p class="publication-links">
-        {{- with .doi -}}
-          <a href="https://doi.org/{{ . }}" target="_blank" rel="noopener">DOI</a>
-        {{- end -}}
-        {{- with .url -}}
-          <a href="{{ . }}" target="_blank" rel="noopener">Link</a>
-        {{- end -}}
-        {{- with .pdf -}}
-          <a href="{{ . | relURL }}" target="_blank" rel="noopener">PDF</a>
-        {{- end -}}
-      </p>
+      <div class="pub-text">
+        <p class="pub-title">{{ $p.title | plainify }}</p>
+        <p class="pub-authors">{{ $p.authors | plainify }}</p>
+        <p class="pub-meta"><em>{{ $p.journal | plainify }}</em> ({{ $p.year }})</p>
+      </div>
+      {{- with $p.image -}}
+      <div class="pub-image">
+        <img src="{{ . }}" alt="illustration for {{ $p.title | plainify }}">
+      </div>
+      {{- end -}}
     </li>
   {{- end -}}
 </ol>

--- a/themes/scilab/assets/css/custom.css
+++ b/themes/scilab/assets/css/custom.css
@@ -8,11 +8,15 @@
 
 /* Publication list styling */
 .publications-list {
-  list-style: none;
+  list-style: decimal;
+  list-style-position: inside;
   padding-left: 0;
   margin: 0;
 }
 .publication-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
   margin-bottom: 1.5rem;
   border-bottom: 1px solid #eee;
   padding-bottom: 1rem;
@@ -20,14 +24,25 @@
 .publication-item:last-child {
   border-bottom: none;
 }
+.pub-text {
+  flex: 0 0 75%;
+}
+.pub-image {
+  flex: 0 0 25%;
+  margin-left: 1rem;
+  text-align: right;
+}
+.pub-image img {
+  max-width: 100%;
+  height: auto;
+}
 .pub-title {
   font-weight: 600;
 }
 .pub-authors {
   color: #555;
 }
-.pub-journal,
-.pub-year {
+.pub-meta {
   color: #888;
   font-size: 0.9rem;
 }


### PR DESCRIPTION
## Summary
- clean up Publications index page
- render publication list from `data/publications.json`
- show optional image next to each publication
- style publication list with numbers and responsive layout

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_687c6e198900832e8f8b0ad2779bff6e