### PR TITLE
Refine layout and resources

### DIFF
--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -12,12 +12,9 @@ You can reach us at:
 
 <div class="contact-grid">
   <div class="contact-map">
-    <!-- Embed your map here.  For example, using an iframe from Google Maps: -->
-    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3022.199171925128!2d-73.99103558459883!3d40.75889527932893!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c258f89a3a3f2f%3A0x91014008b5b95b44!2sYour%20Lab%20Location!5e0!3m2!1sen!2sus!4v1678889999999!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+    <iframe width="600" height="450" frameborder="0" scrolling="no" src="https://www.openstreetmap.org/export/embed.html?bbox=-117.255%2C32.865%2C-117.253%2C32.867&amp;layer=mapnik&amp;marker=32.866%2C-117.254"></iframe>
   </div>
   <div class="contact-details">
-    <b>Address: </b>
-    Bio Lab, Department of Biophysics, 456 Research Avenue, Science City, 12345, USA
-    <!--  Add more details as needed -->
+    <b>Address:</b> Scripps Pier, La Jolla, San Diego, CA 92037
   </div>
 </div>

--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -2,10 +2,13 @@
 title: "Resources"
 ---
 
-# Lab Resources & Protocols
-
-[![](/images/cryo-em-setup.jpg)](/images/cryo-em-setup.jpg)
-
-Our lab is equipped with state-of-the-art facilities for cryo-EM sample preparation, data acquisition, and analysis. We have access to high-end microscopes and computational resources.
+Our lab maintains a collection of external resources.
 
 ## Protocols
+- [Cryo-EM Sample Preparation](https://example.com/sample-prep)
+- [Image Processing Workflow](https://example.com/image-processing)
+- [Data Collection Guide](https://example.com/data-collection)
+
+## Other Resources
+- [Analysis Scripts on GitHub](https://github.com/example/repo)
+- [Plasmid Database](https://example.com/plasmids)

--- a/layouts/shortcodes/publication.html
+++ b/layouts/shortcodes/publication.html
@@ -8,11 +8,9 @@
 {{- if $pub -}}
 <div class="publication">
     <p>
-        {{ $pub.authors }} ({{ $pub.year }}).
-        {{- with $pub.link -}}<a href="{{ . }}" target="_blank" rel="noopener">{{- end -}}
-        {{ $pub.title }}.
-        {{- if $pub.link -}}</a>{{- end -}}
+        {{ $pub.authors }} ({{ $pub.year }}). {{ $pub.title }}.
         <em>{{ $pub.journal }}</em>{{ with $pub.volume }}, {{ . }}{{ end }}{{ with $pub.pages }}, {{ . }}{{ end }}.
+        {{- with $pub.link }} [<a href="{{ . }}" target="_blank" rel="noopener">link</a>]{{- end }}
     </p>
 </div>
 {{- end -}}

--- a/layouts/shortcodes/publications.html
+++ b/layouts/shortcodes/publications.html
@@ -15,7 +15,7 @@
       <div class="pub-text">
         <p class="pub-title">{{ $p.title | plainify }}</p>
         <p class="pub-authors">{{ $p.authors | plainify }}</p>
-        <p class="pub-meta"><em>{{ $p.journal | plainify }}</em> ({{ $p.year }})</p>
+        <p class="pub-meta"><em>{{ $p.journal | plainify }}</em> ({{ $p.year }}) {{- with $p.link -}}[<a href="{{ . }}" target="_blank" rel="noopener">link</a>]{{- end -}}</p>
       </div>
       {{- with $p.image -}}
       <div class="pub-image">

--- a/layouts/team/list.html
+++ b/layouts/team/list.html
@@ -21,6 +21,7 @@
         <img src="{{ .Params.image | safeURL }}" alt="{{ .Title }}">
         <h3>{{ .Title }}</h3>
         <p class="role">{{ .Params.role }}</p>
+        <p class="email"><a href="mailto:{{ .Params.email }}">{{ .Params.email }}</a></p>
         <div class="content">{{ .Content }}</div>
       </div>
     {{ end }}

--- a/themes/scilab/assets/css/custom.css
+++ b/themes/scilab/assets/css/custom.css
@@ -17,7 +17,7 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   border-bottom: 1px solid #eee;
   padding-bottom: 0.2rem;
 }
@@ -36,6 +36,10 @@
   max-width: 100%;
   height: auto;
 }
+.publication-item p {
+  margin: 0;
+  margin-bottom: 0.25rem;
+}
 .pub-title {
   font-weight: 600;
 }
@@ -45,4 +49,5 @@
 .pub-meta {
   color: #888;
   font-size: 0.9rem;
+  margin-bottom: 0;
 }

--- a/themes/scilab/assets/css/main.css
+++ b/themes/scilab/assets/css/main.css
@@ -23,9 +23,9 @@ body {
 
 /* Header and Navigation */
 .header {
-    padding: 2rem 0;
+    padding: 1.5rem 0;
     border-bottom: 1px solid #eee;
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem;
 }
 
 .header .container {
@@ -71,13 +71,18 @@ body {
     flex-grow: 1;
 }
 
+p {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+}
+
 /* Headings */
 h1, h2, h3, h4, h5, h6 {
     font-weight: 700;
     color: #000;
-    padding-top: 1rem;
-    margin-top: 1rem;
-    margin-bottom: 1rem;
+    padding-top: 0.5rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
 }
 
 h1 { font-size: 2.5rem; }
@@ -97,7 +102,7 @@ a:hover {
 /* Home Page Specifics */
 .hero {
     text-align: center;
-    padding: 4rem 0;
+    padding: 3rem 0;
 }
 
 .hero h1 {
@@ -186,7 +191,7 @@ a:hover {
 .team-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    gap: 2rem;
+    gap: 1.5rem;
 }
 
 .team-member {
@@ -204,8 +209,8 @@ a:hover {
 .team-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); /* Adjust min width as needed */
-    gap: 2rem;
-    margin-top: 2rem;
+    gap: 1.5rem;
+    margin-top: 1.5rem;
 }
 
 .team-member {


### PR DESCRIPTION
## Summary
- add openstreetmap contact map for Scripps Pier
- clean up resources page with external links
- show team member emails
- display paper links in publications shortcode
- tighten publication styles and general spacing

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_687c81b996bc832ebdbff3f50c32c9b3