### PR TITLE
Fix image URLs for Hugo site

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,9 +4,9 @@ title: "Bio Lab"
 
 <section class="hero">
   <div class="carousel">
-    <img src="{{ "/images/lab.jpg" | absURL }}" alt="Lab image 1">
-    <img src="{{ "/images/img1.jpg" | absURL }}" alt="Lab image 2">
-    <img src="{{ "/images/img2.jpg" | absURL }}" alt="Lab image 3">
+    <img src="/images/lab.jpg" alt="Lab image 1">
+    <img src="/images/img1.jpg" alt="Lab image 2">
+    <img src="/images/img2.jpg" alt="Lab image 3">
   </div>
   <h1>Welcome to Bio Lab</h1>
   <p>We are a cutting-edge biophysics laboratory dedicated to unraveling the complexities of biological systems through innovative research and interdisciplinary collaboration.</p>

--- a/content/labfun/_index.md
+++ b/content/labfun/_index.md
@@ -7,12 +7,12 @@ title: "Lab Fun"
 We believe that a positive and collaborative lab environment fosters creativity and productivity. Here are some glimpses into our lab life:
 
 
-[![]({{ "/images/img1.jpg" | absURL }})]({{ "/images/img1.jpg" | absURL }})
+[![](/images/img1.jpg)](/images/img1.jpg)
 
 We enjoy team outings and social events to unwind and connect outside of research.
 
 
-[![]({{ "/images/img2.jpg" | absURL }})]({{ "/images/img2.jpg" | absURL }})
+[![](/images/img2.jpg)](/images/img2.jpg)
 
 Our team collaborates closely on data analysis and troubleshooting, celebrating successes together.
 

--- a/content/research/_index.md
+++ b/content/research/_index.md
@@ -15,12 +15,12 @@ We are particularly interested in viruses with significant public health impact,
 
 ### Project 1:  Understanding Virus X Assembly
 
-[![]({{ "/images/img1.jpg" | absURL }})]({{ "/images/img1.jpg" | absURL }})
+[![](/images/img1.jpg)](/images/img1.jpg)
 
 We are investigating the assembly mechanism of Virus X using cryo-EM. This project focuses on identifying key structural intermediates and understanding the roles of different viral proteins in the assembly process.
 
 ### Project 2: Developing Novel Inhibitors for Virus Y
 
-[![]({{ "/images/img2.jpg" | absURL }})]({{ "/images/img2.jpg" | absURL }})
+[![](/images/img2.jpg)](/images/img2.jpg)
 
 This project aims to identify and characterize novel inhibitors that target Virus Y. We use cryo-EM to visualize inhibitor binding and understand the structural basis of inhibition, which can inform the development of antiviral therapeutics.

--- a/content/team/_index.md
+++ b/content/team/_index.md
@@ -2,4 +2,4 @@
 title: "Team"
 ---
 
-<img src="{{ "/images/lab.jpg" | absURL }}" alt="Lab image 1">
+<img src="/images/lab.jpg" alt="Lab image 1">

--- a/hugo.toml
+++ b/hugo.toml
@@ -4,6 +4,7 @@ languageCode = "en-us"
 title = "Bio Lab"
 theme = "scilab"
 
+canonifyURLs = true
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]

--- a/layouts/team/list.html
+++ b/layouts/team/list.html
@@ -5,7 +5,7 @@
   {{ $pi := where .Pages "Params.type" "pi" }}
   {{ range $pi }}
     <div class="team-member pi">
-      <img src="{{ .Params.image | absURL | safeURL }}" alt="{{ .Title }}">
+      <img src="{{ .Params.image | relURL | safeURL }}" alt="{{ .Title }}">
       <div class="info">
         <h2>{{ .Title }}</h2>
         <p class="email"><a href="mailto:{{ .Params.email }}">{{ .Params.email }}</a></p>
@@ -18,7 +18,7 @@
     {{ $members := where .Pages "Params.type" "member" }}
     {{ range $members }}
       <div class="team-member">
-        <img src="{{ .Params.image | absURL | safeURL }}" alt="{{ .Title }}">
+        <img src="{{ .Params.image | relURL | safeURL }}" alt="{{ .Title }}">
         <h3>{{ .Title }}</h3>
         <p class="role">{{ .Params.role }}</p>
         <p class="email"><a href="mailto:{{ .Params.email }}">{{ .Params.email }}</a></p>


### PR DESCRIPTION
## Summary
- make images work with GitHub Pages by enabling `canonifyURLs`
- generate relative URLs for team member photos
- use direct links for hero, research, and lab fun images

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_687d3e872df8832e9e209967ca19a7db